### PR TITLE
Adopt code to pandas 1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# Visual Studio Code project settings
+.vscode
+
 # Rope project settings
 .ropeproject
 

--- a/epysurv/models/timeseries/_base.py
+++ b/epysurv/models/timeseries/_base.py
@@ -21,4 +21,6 @@ class NonLearningTimeseriesClassificationMixin:
             [time] = prediction.index
             alarms.append(alarm)
             times.append(time)
-        return pd.DataFrame({"alarm": alarms}, index=pd.DatetimeIndex(times))
+        return pd.DataFrame(
+            {"alarm": alarms}, index=pd.DatetimeIndex(times, freq="infer")
+        )

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -10,12 +10,7 @@ from epysurv.simulation import (
     SeasonalNoisePoisson,
 )
 
-
-def load_simulations(filepath):
-    simulations = pd.read_csv(
-        filepath, index_col=0, parse_dates=True, infer_datetime_format=True
-    )
-    return simulations
+from .utils import load_simulations
 
 
 @pytest.mark.parametrize(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,5 +5,13 @@ def load_predictions(filepath):
     predictions = pd.read_csv(
         filepath, index_col=0, parse_dates=True, infer_datetime_format=True
     ).assign(alarm=lambda df: df["alarm"].astype(bool))
+    freq = pd.infer_freq(predictions.index)
+    return predictions.asfreq(freq)
 
-    return predictions
+
+def load_simulations(filepath):
+    simulations = pd.read_csv(
+        filepath, index_col=0, parse_dates=True, infer_datetime_format=True
+    )
+    freq = pd.infer_freq(simulations.index)
+    return simulations.asfreq(freq)


### PR DESCRIPTION
With the newest change in pandas, the frequency
of a DateTimeIndex is not automatically inferred
as expected by the previous code.
This PR makes the inferrence of the DateTimeIndex
frequency explicit.

Furthermore, it moves one function to read in files
to tests/utils.py where together with a similar
function.